### PR TITLE
Add an option to not mask null values

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ sekret {
     // true by default
     enabled = true  
     
-    // false by default
-    maskNulls = true  
+    // true by default
+    maskNulls = false  
     
     // "dev.afanasev.sekret.Secret" by default
     annotations = ["com.sample.YourAnnotation"] 

--- a/README.md
+++ b/README.md
@@ -53,14 +53,17 @@ dependencies {
 
 // OR use your own
 sekret {
+    // "■■■" by default
+    mask = "***"    
+    
     // true by default
     enabled = true  
     
-    // "dev.afanasev.sekret.Secret" by default
-    annotations = ["com.sample.YourAnnotation"]
+    // false by default
+    maskNulls = true  
     
-    // "■■■" by default
-    mask = "***" 
+    // "dev.afanasev.sekret.Secret" by default
+    annotations = ["com.sample.YourAnnotation"] 
 }
 ```
 

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     kotlin("jvm")
     kotlin("kapt")
     `java-gradle-plugin`
-    id("com.gradle.plugin-publish") version "0.10.0"
+    id("com.gradle.plugin-publish") version "0.11.0"
 }
 
 dependencies {


### PR DESCRIPTION
Requested: 
https://github.com/aafanasev/sekret/issues/10

Config:
```groovy 
sekret {
  maskNulls = false
}
```

Given:
```kotlin
data class User(username: String, password: String?)
print(User("Agent", null))
```

Before:
```sh
User(login=Agent, password=■■■)
```

After:
```sh
User(login=Agent, password=null)
```
