### PR TITLE
Fix #26 NPE during generateToString

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,3 +5,4 @@ indent_size = 4
 indent_style = space
 insert_final_newline = true
 end_of_line = lf
+max_line_length = 200

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -25,10 +25,6 @@ tasks.withType<KotlinCompile>().configureEach {
 }
 
 kotlin {
-    jvmToolchain {
-        (this as JavaToolchainSpec).languageVersion.set(JavaLanguageVersion.of(8))
-    }
-
     kotlinDslPluginOptions {
         jvmTarget.set("1.8")
     }

--- a/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 kotlin {
     jvmToolchain {
-        (this as JavaToolchainSpec).languageVersion.set(JavaLanguageVersion.of("8"))
+        languageVersion.set(JavaLanguageVersion.of("8"))
     }
 }
 

--- a/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm.gradle.kts
@@ -6,9 +6,6 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of("8"))
-    }
 }
 
 java {

--- a/kotlin-plugin/src/main/kotlin/net/afanasev/sekret/kotlin/FieldInfo.kt
+++ b/kotlin-plugin/src/main/kotlin/net/afanasev/sekret/kotlin/FieldInfo.kt
@@ -1,0 +1,7 @@
+package net.afanasev.sekret.kotlin
+
+data class FieldInfo(
+    val desc: String,
+    val needToHide: Boolean,
+    val isNullable: Boolean,
+)

--- a/kotlin-plugin/src/main/kotlin/net/afanasev/sekret/kotlin/FieldInfo.kt
+++ b/kotlin-plugin/src/main/kotlin/net/afanasev/sekret/kotlin/FieldInfo.kt
@@ -4,4 +4,5 @@ data class FieldInfo(
     val desc: String,
     val needToHide: Boolean,
     val isNullable: Boolean,
+    val wrapperClassName: String?,
 )

--- a/kotlin-plugin/src/main/kotlin/net/afanasev/sekret/kotlin/SekretClassBuilder.kt
+++ b/kotlin-plugin/src/main/kotlin/net/afanasev/sekret/kotlin/SekretClassBuilder.kt
@@ -26,8 +26,6 @@ class SekretClassBuilder(
     private val fields = linkedMapOf<String, FieldInfo?>()
     private var generateToString = false
 
-    private var error = ""
-
     override fun getDelegate(): ClassBuilder = classBuilder
 
     override fun newField(
@@ -107,9 +105,6 @@ class SekretClassBuilder(
 
     override fun done() {
         if (generateToString) {
-            if (error.isNotEmpty()) {
-                throw java.lang.RuntimeException(error)
-            }
             generateToString()
         }
         super.done()

--- a/kotlin-plugin/src/main/kotlin/net/afanasev/sekret/kotlin/SekretClassBuilder.kt
+++ b/kotlin-plugin/src/main/kotlin/net/afanasev/sekret/kotlin/SekretClassBuilder.kt
@@ -82,7 +82,7 @@ class SekretClassBuilder(
                         && owner == origin.classDescriptor()
                         && name.startsWith("get")
                     ) {
-                        val keyName = name.substring(3).replaceFirstChar { it.lowercase() }
+                        val keyName = name.substring(3).substringBefore("-").replaceFirstChar { it.lowercase() }
                         println("skipping $owner/$keyName/$descriptor - opcode $opcode=='INVOKE VIRTUAL'. interface:$isInterface")
                         fields[keyName] = null
                     }
@@ -112,11 +112,7 @@ class SekretClassBuilder(
         appendToStringBuilder(mv)
 
         fields.onEachIndexed { index, (name, fieldInfo) ->
-
-            if (fieldInfo == null) {
-                println("WARNING $index/$name has no field info")
-                return@onEachIndexed
-            }
+            checkNotNull(fieldInfo) { name }
 
             mv.visitLdcInsn((if (index == 0) "" else ", ") + "$name=")
             appendToStringBuilder(mv)
@@ -153,7 +149,7 @@ class SekretClassBuilder(
                         appendToStringBuilder(mv, fieldInfo.desc)
                     }
                     // arrays
-                    fieldInfo.desc[0] == '['                                             -> {
+                    fieldInfo.desc[0] == '[' -> {
                         val isPrimitiveArray = fieldInfo.desc.length == 2
                         mv.visitMethodInsn(
                             Opcodes.INVOKESTATIC,
@@ -165,7 +161,7 @@ class SekretClassBuilder(
                         appendToStringBuilder(mv)
                     }
                     // others go as Object
-                    else                                                                 -> {
+                    else -> {
                         appendToStringBuilder(mv, "Ljava/lang/Object;")
                     }
                 }

--- a/kotlin-plugin/src/main/kotlin/net/afanasev/sekret/kotlin/SekretClassBuilder.kt
+++ b/kotlin-plugin/src/main/kotlin/net/afanasev/sekret/kotlin/SekretClassBuilder.kt
@@ -91,7 +91,12 @@ class SekretClassBuilder(
                         fields[keyName] = null
                     } else if (opcode == Opcodes.INVOKESTATIC && name == TO_STRING_IMPL) {
                         // lastly added field should be wrapped
-                        fields[fields.keys.last()] = FieldInfo("", false, false, owner)
+                        fields[fields.keys.last()] = FieldInfo(
+                            desc = "",
+                            needToHide = false,
+                            isNullable = false,
+                            wrapperClassName = owner
+                        )
                     }
                 }
             }

--- a/sample/src/main/kotlin/net/afanasev/sekret/sample/App.kt
+++ b/sample/src/main/kotlin/net/afanasev/sekret/sample/App.kt
@@ -91,4 +91,8 @@ fun main() {
             student = Student("student", "pwd"),
         )
     )
+
+    Interface.main()
+    VC.main()
+
 }

--- a/sample/src/main/kotlin/net/afanasev/sekret/sample/interfaces.kt
+++ b/sample/src/main/kotlin/net/afanasev/sekret/sample/interfaces.kt
@@ -1,0 +1,52 @@
+package net.afanasev.sekret.sample
+
+import net.afanasev.sekret.Secret
+
+@Suppress("ArrayInDataClass")
+data class ComplexImpl(
+    @Secret override val str: String,
+    @Secret override val int: Int,
+    @Secret override val long: Long,
+    @Secret override val float: Float,
+    @Secret override val list: List<String>,
+    @Secret override val array: Array<Char>,
+    @Secret override var boolean: Boolean,
+    override val admin: Admin,
+    @Secret override val student: Student,
+) : ComplexInterface {
+    companion object {
+        const val CONST = "const"
+    }
+
+    val field1 = ""
+    var field2 = false
+}
+
+interface ComplexInterface {
+
+    val str: String
+    val int: Int
+    val long: Long
+    val float: Float
+    val list: List<String>
+    val array: Array<Char>
+    var boolean: Boolean
+    val admin: Admin
+    val student: Student
+}
+
+fun main() {
+    println(
+        ComplexImpl(
+            str = "string",
+            int = 3,
+            long = 4L,
+            float = 2f,
+            list = listOf(),
+            array = arrayOf(),
+            boolean = true,
+            admin = Admin("admin", "pwd"),
+            student = Student("student", "pwd"),
+        )
+    )
+}

--- a/sample/src/main/kotlin/net/afanasev/sekret/sample/interfaces.kt
+++ b/sample/src/main/kotlin/net/afanasev/sekret/sample/interfaces.kt
@@ -35,18 +35,20 @@ interface ComplexInterface {
     val student: Student
 }
 
-fun main() {
-    println(
-        ComplexImpl(
-            str = "string",
-            int = 3,
-            long = 4L,
-            float = 2f,
-            list = listOf(),
-            array = arrayOf(),
-            boolean = true,
-            admin = Admin("admin", "pwd"),
-            student = Student("student", "pwd"),
+object Interface {
+    fun main() {
+        println(
+            ComplexImpl(
+                str = "string",
+                int = 3,
+                long = 4L,
+                float = 2f,
+                list = listOf(),
+                array = arrayOf(),
+                boolean = true,
+                admin = Admin("admin", "pwd"),
+                student = Student("student", "pwd"),
+            )
         )
-    )
+    }
 }

--- a/sample/src/main/kotlin/net/afanasev/sekret/sample/valueClasses.kt
+++ b/sample/src/main/kotlin/net/afanasev/sekret/sample/valueClasses.kt
@@ -12,12 +12,16 @@ value class Name(val value: String) {
 }
 
 @JvmInline
+value class NestedName(val name: Name)
+
+@JvmInline
 value class Description(val value: String)
 
 // regular data class - expect Secket has no effect
 data class MyModel(
     val id: ModelId,
     val name: Name,
+    val nestedName: NestedName,
     val description: Description?,
 )
 
@@ -25,6 +29,7 @@ data class MyModel(
 data class MyModelSecret(
     @Secret val id: ModelId,
     @Secret val name: Name,
+    @Secret val nestedName: NestedName,
     @Secret val description: Description?,
 )
 
@@ -32,6 +37,7 @@ data class MyModelSecret(
 data class MySubModel(
     override val id: ModelId,
     override val name: Name,
+    override val nestedName: NestedName,
     override val description: Description?,
     val extraField: String,
 ) : MyModelInterface
@@ -40,6 +46,7 @@ data class MySubModel(
 data class MySubModelSecret(
     @Secret override val id: ModelId,
     @Secret override val name: Name,
+    @Secret override val nestedName: NestedName,
     @Secret override val description: Description?,
     @Secret val anotherExtraField: String,
 ) : MyModelInterface
@@ -47,29 +54,27 @@ data class MySubModelSecret(
 interface MyModelInterface {
     val id: ModelId
     val name: Name
+    val nestedName: NestedName
     val description: Description?
 }
 
-fun main() {
-
-}
 object VC {
     fun main() {
         val modelId = ModelId(111)
         val name = Name("name")
+        val nestedName = NestedName(Name("nested"))
         val description = Description("description")
 
         println(modelId)
         println(name)
         println(description)
 
-        println(MyModel(modelId, name, description))
+        println(MyModel(modelId, name, nestedName, description))
 
-        println(MyModelSecret(modelId, name, description))
+        println(MyModelSecret(modelId, name, nestedName, description))
 
-        println(MySubModel(modelId, name, description, "extra-field"))
+        println(MySubModel(modelId, name, nestedName, description, "extra-field"))
 
-        println(MySubModelSecret(modelId, name, description, "another-extra-field"))
-
+        println(MySubModelSecret(modelId, name, nestedName, description, "another-extra-field"))
     }
 }

--- a/sample/src/main/kotlin/net/afanasev/sekret/sample/valueClasses.kt
+++ b/sample/src/main/kotlin/net/afanasev/sekret/sample/valueClasses.kt
@@ -5,8 +5,10 @@ import net.afanasev.sekret.Secret
 
 @JvmInline
 value class ModelId(val value: Long) : Comparable<Long> by value
+
 @JvmInline
 value class Name(val value: String) : CharSequence by value
+
 @JvmInline
 value class Description(val value: String)
 
@@ -47,20 +49,25 @@ interface MyModelInterface {
 }
 
 fun main() {
-    val modelId = ModelId(111)
-    val name = Name("name")
-    val description = Description("description")
 
-    println(modelId)
-    println(name)
-    println(description)
+}
+object VC {
+    fun main() {
+        val modelId = ModelId(111)
+        val name = Name("name")
+        val description = Description("description")
 
-    println(MyModel(modelId, name, description))
+        println(modelId)
+        println(name)
+        println(description)
 
-    println(MyModelSecret(modelId, name, description))
+        println(MyModel(modelId, name, description))
 
-    println(MySubModel(modelId, name, description, "extra-field"))
+        println(MyModelSecret(modelId, name, description))
 
-    println(MySubModelSecret(modelId, name, description, "another-extra-field"))
+        println(MySubModel(modelId, name, description, "extra-field"))
 
+        println(MySubModelSecret(modelId, name, description, "another-extra-field"))
+
+    }
 }

--- a/sample/src/main/kotlin/net/afanasev/sekret/sample/valueClasses.kt
+++ b/sample/src/main/kotlin/net/afanasev/sekret/sample/valueClasses.kt
@@ -7,7 +7,9 @@ import net.afanasev.sekret.Secret
 value class ModelId(val value: Long) : Comparable<Long> by value
 
 @JvmInline
-value class Name(val value: String) : CharSequence by value
+value class Name(val value: String) {
+    override fun toString(): String = "my name is $value"
+}
 
 @JvmInline
 value class Description(val value: String)

--- a/sample/src/main/kotlin/net/afanasev/sekret/sample/valueClasses.kt
+++ b/sample/src/main/kotlin/net/afanasev/sekret/sample/valueClasses.kt
@@ -1,0 +1,66 @@
+package net.afanasev.sekret.sample
+
+import net.afanasev.sekret.Secret
+
+
+@JvmInline
+value class ModelId(val value: Long) : Comparable<Long> by value
+@JvmInline
+value class Name(val value: String) : CharSequence by value
+@JvmInline
+value class Description(val value: String)
+
+// regular data class - expect Secket has no effect
+data class MyModel(
+    val id: ModelId,
+    val name: Name,
+    val description: Description?,
+)
+
+// Secket should censor all @Secret fields from toString()
+data class MyModelSecret(
+    @Secret val id: ModelId,
+    @Secret val name: Name,
+    @Secret val description: Description?,
+)
+
+// regular data class - expect Secket has no effect
+data class MySubModel(
+    override val id: ModelId,
+    override val name: Name,
+    override val description: Description?,
+    val extraField: String,
+) : MyModelInterface
+
+// Secket should censor all @Secret fields from toString()
+data class MySubModelSecret(
+    @Secret override val id: ModelId,
+    @Secret override val name: Name,
+    @Secret override val description: Description?,
+    @Secret val anotherExtraField: String,
+) : MyModelInterface
+
+interface MyModelInterface {
+    val id: ModelId
+    val name: Name
+    val description: Description?
+}
+
+fun main() {
+    val modelId = ModelId(111)
+    val name = Name("name")
+    val description = Description("description")
+
+    println(modelId)
+    println(name)
+    println(description)
+
+    println(MyModel(modelId, name, description))
+
+    println(MyModelSecret(modelId, name, description))
+
+    println(MySubModel(modelId, name, description, "extra-field"))
+
+    println(MySubModelSecret(modelId, name, description, "another-extra-field"))
+
+}

--- a/sample/src/test/kotlin/net/afanasev/sekret/sample/InterfaceSpec.kt
+++ b/sample/src/test/kotlin/net/afanasev/sekret/sample/InterfaceSpec.kt
@@ -12,15 +12,15 @@ object InterfaceSpec : Spek({
         it("annotated properties should be hidden") {
             assertEquals(
                 "ComplexImpl(" +
-                    "str=■■■, " +
-                    "int=■■■, " +
-                    "long=■■■, " +
-                    "float=■■■, " +
-                    "list=■■■, " +
-                    "array=■■■, " +
-                    "boolean=■■■, " +
-                    "admin=Admin(login=admin, password=■■■), " +
-                    "student=■■■" +
+                    "str=$mask, " +
+                    "int=$mask, " +
+                    "long=$mask, " +
+                    "float=$mask, " +
+                    "list=$mask, " +
+                    "array=$mask, " +
+                    "boolean=$mask, " +
+                    "admin=Admin(login=admin, password=$mask), " +
+                    "student=$mask" +
                     ")",
                 ComplexImpl(
                     str = "string",

--- a/sample/src/test/kotlin/net/afanasev/sekret/sample/InterfaceSpec.kt
+++ b/sample/src/test/kotlin/net/afanasev/sekret/sample/InterfaceSpec.kt
@@ -1,0 +1,39 @@
+package net.afanasev.sekret.sample
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object InterfaceSpec : Spek({
+
+    describe("data class that implements an interface") {
+        val mask = "■■■"
+
+        it("annotated properties should be hidden") {
+            assertEquals(
+                "ComplexImpl(" +
+                    "str=■■■, " +
+                    "int=■■■, " +
+                    "long=■■■, " +
+                    "float=■■■, " +
+                    "list=■■■, " +
+                    "array=■■■, " +
+                    "boolean=■■■, " +
+                    "admin=Admin(login=admin, password=■■■), " +
+                    "student=■■■" +
+                    ")",
+                ComplexImpl(
+                    str = "string",
+                    int = 3,
+                    long = 4L,
+                    float = 2f,
+                    list = listOf(),
+                    array = arrayOf(),
+                    boolean = true,
+                    admin = Admin("admin", "pwd"),
+                    student = Student("student", "pwd"),
+                ).toString()
+            )
+        }
+    }
+})

--- a/sample/src/test/kotlin/net/afanasev/sekret/sample/SekretSpec.kt
+++ b/sample/src/test/kotlin/net/afanasev/sekret/sample/SekretSpec.kt
@@ -33,6 +33,37 @@ object SekretSpec : Spek({
         it("should hide getters") {
             assertEquals("BaseImpl(str=$mask, id=$mask, arr=$mask, str2=$mask, str3=str3)", BaseImpl("str", 42, arrayOf("a", "r"), "str3", "str3").toString())
         }
+
+        it("should hide getters") {
+            assertEquals("BaseImpl(str=$mask, id=$mask, arr=$mask, str2=$mask, str3=str3)", BaseImpl("str", 42, arrayOf("a", "r"), "str3", "str3").toString())
+        }
+
+        it("should hide properties of a complex object") {
+            assertEquals(
+                "Complex(" +
+                    "str=■■■, " +
+                    "int=■■■, " +
+                    "long=■■■, " +
+                    "float=■■■, " +
+                    "list=■■■, " +
+                    "array=■■■, " +
+                    "boolean=■■■, " +
+                    "admin=Admin(login=admin, password=■■■), " +
+                    "student=■■■" +
+                    ")",
+                Complex(
+                    str = "string",
+                    int = 3,
+                    long = 4L,
+                    float = 2f,
+                    list = listOf(),
+                    array = arrayOf(),
+                    boolean = true,
+                    admin = Admin("admin", "pwd"),
+                    student = Student("student", "pwd"),
+                ).toString()
+            )
+        }
     }
 
 })

--- a/sample/src/test/kotlin/net/afanasev/sekret/sample/SekretSpec.kt
+++ b/sample/src/test/kotlin/net/afanasev/sekret/sample/SekretSpec.kt
@@ -41,15 +41,15 @@ object SekretSpec : Spek({
         it("should hide properties of a complex object") {
             assertEquals(
                 "Complex(" +
-                    "str=■■■, " +
-                    "int=■■■, " +
-                    "long=■■■, " +
-                    "float=■■■, " +
-                    "list=■■■, " +
-                    "array=■■■, " +
-                    "boolean=■■■, " +
-                    "admin=Admin(login=admin, password=■■■), " +
-                    "student=■■■" +
+                    "str=$mask, " +
+                    "int=$mask, " +
+                    "long=$mask, " +
+                    "float=$mask, " +
+                    "list=$mask, " +
+                    "array=$mask, " +
+                    "boolean=$mask, " +
+                    "admin=Admin(login=admin, password=$mask), " +
+                    "student=$mask" +
                     ")",
                 Complex(
                     str = "string",

--- a/sample/src/test/kotlin/net/afanasev/sekret/sample/ValueClassSpec.kt
+++ b/sample/src/test/kotlin/net/afanasev/sekret/sample/ValueClassSpec.kt
@@ -7,6 +7,7 @@ import org.spekframework.spek2.style.specification.describe
 object ValueClassSpec : Spek({
     val modelId = ModelId(111)
     val name = Name("name")
+    val nestedName = NestedName(Name("nested"))
     val description = Description("description")
 
     describe("data class with value class properties") {
@@ -14,15 +15,25 @@ object ValueClassSpec : Spek({
 
         it("should print non-annotated properties") {
             assertEquals(
-                "MyModel(id=ModelId(value=111), name=my name is name, description=Description(value=description))",
-                MyModel(modelId, name, description).toString()
+                "MyModel(" +
+                    "id=ModelId(value=111), " +
+                    "name=my name is name, " +
+                    "nestedName=NestedName(name=my name is nested), " +
+                    "description=Description(value=description)" +
+                    ")",
+                MyModel(modelId, name, nestedName, description).toString()
             )
         }
 
         it("should hide annotated properties") {
             assertEquals(
-                "MyModelSecret(id=$mask, name=$mask, description=$mask)",
-                MyModelSecret(modelId, name, description).toString()
+                "MyModelSecret(" +
+                    "id=$mask, " +
+                    "name=$mask, " +
+                    "nestedName=$mask, " +
+                    "description=$mask" +
+                    ")",
+                MyModelSecret(modelId, name, nestedName, description).toString()
             )
         }
 
@@ -30,15 +41,27 @@ object ValueClassSpec : Spek({
 
             it("should print non-annotated properties") {
                 assertEquals(
-                    "MySubModel(id=ModelId(value=111), name=my name is name, description=Description(value=description), extraField=extra-field)",
-                    MySubModel(modelId, name, description, "extra-field").toString()
+                    "MySubModel(" +
+                        "id=ModelId(value=111), " +
+                        "name=my name is name, " +
+                        "nestedName=NestedName(name=my name is nested), " +
+                        "description=Description(value=description), " +
+                        "extraField=extra-field" +
+                        ")",
+                    MySubModel(modelId, name, nestedName, description, "extra-field").toString()
                 )
             }
 
             it("should hide annotated properties") {
                 assertEquals(
-                    "MySubModelSecret(id=$mask, name=$mask, description=$mask, anotherExtraField=$mask)",
-                    MySubModelSecret(modelId, name, description, "another-extra-field").toString()
+                    "MySubModelSecret(" +
+                        "id=$mask, " +
+                        "name=$mask, " +
+                        "nestedName=$mask, " +
+                        "description=$mask, " +
+                        "anotherExtraField=$mask" +
+                        ")",
+                    MySubModelSecret(modelId, name, nestedName, description, "another-extra-field").toString()
                 )
             }
         }

--- a/sample/src/test/kotlin/net/afanasev/sekret/sample/ValueClassSpec.kt
+++ b/sample/src/test/kotlin/net/afanasev/sekret/sample/ValueClassSpec.kt
@@ -1,0 +1,47 @@
+package net.afanasev.sekret.sample
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object ValueClassSpec : Spek({
+    val modelId = ModelId(111)
+    val name = Name("name")
+    val description = Description("description")
+
+    describe("data class with value class properties") {
+        val mask = "■■■"
+
+        it("should print properties that are value classes, and not annotated") {
+            assertEquals(
+                "MyModel(id=ModelId(value=111), name=Name(value=name), description=Description(value=description))",
+                MyModel(modelId, name, description).toString()
+            )
+        }
+
+        it("should hide properties that are value classes, and are annotated") {
+            assertEquals(
+                "MyModelSecret(id=$mask, name=$mask, description=$mask)",
+                MyModelSecret(modelId, name, description).toString()
+            )
+        }
+
+        describe("that implement an interface") {
+
+            it("should print properties that are value classes, and not annotated") {
+                assertEquals(
+                    "MySubModel(id=ModelId(value=111), name=Name(value=name), description=Description(value=description), extraField=extra-field)",
+                    MySubModel(modelId, name, description, "extra-field").toString()
+                )
+            }
+
+            it("should hide properties that are value classes, and are annotated") {
+                assertEquals(
+                    "MySubModelSecret(id=$mask, name=$mask, description=$mask, anotherExtraField=$mask)",
+                    MySubModelSecret(modelId, name, description, "another-extra-field").toString()
+                )
+            }
+        }
+    }
+
+})

--- a/sample/src/test/kotlin/net/afanasev/sekret/sample/ValueClassSpec.kt
+++ b/sample/src/test/kotlin/net/afanasev/sekret/sample/ValueClassSpec.kt
@@ -12,14 +12,14 @@ object ValueClassSpec : Spek({
     describe("data class with value class properties") {
         val mask = "■■■"
 
-        it("should print properties that are value classes, and not annotated") {
+        it("should print non-annotated properties") {
             assertEquals(
                 "MyModel(id=ModelId(value=111), name=Name(value=name), description=Description(value=description))",
                 MyModel(modelId, name, description).toString()
             )
         }
 
-        it("should hide properties that are value classes, and are annotated") {
+        it("should hide annotated properties") {
             assertEquals(
                 "MyModelSecret(id=$mask, name=$mask, description=$mask)",
                 MyModelSecret(modelId, name, description).toString()
@@ -28,14 +28,14 @@ object ValueClassSpec : Spek({
 
         describe("that implement an interface") {
 
-            it("should print properties that are value classes, and not annotated") {
+            it("should print non-annotated properties") {
                 assertEquals(
                     "MySubModel(id=ModelId(value=111), name=Name(value=name), description=Description(value=description), extraField=extra-field)",
                     MySubModel(modelId, name, description, "extra-field").toString()
                 )
             }
 
-            it("should hide properties that are value classes, and are annotated") {
+            it("should hide annotated properties") {
                 assertEquals(
                     "MySubModelSecret(id=$mask, name=$mask, description=$mask, anotherExtraField=$mask)",
                     MySubModelSecret(modelId, name, description, "another-extra-field").toString()

--- a/sample/src/test/kotlin/net/afanasev/sekret/sample/ValueClassSpec.kt
+++ b/sample/src/test/kotlin/net/afanasev/sekret/sample/ValueClassSpec.kt
@@ -14,7 +14,7 @@ object ValueClassSpec : Spek({
 
         it("should print non-annotated properties") {
             assertEquals(
-                "MyModel(id=ModelId(value=111), name=Name(value=name), description=Description(value=description))",
+                "MyModel(id=ModelId(value=111), name=my name is name, description=Description(value=description))",
                 MyModel(modelId, name, description).toString()
             )
         }
@@ -30,7 +30,7 @@ object ValueClassSpec : Spek({
 
             it("should print non-annotated properties") {
                 assertEquals(
-                    "MySubModel(id=ModelId(value=111), name=Name(value=name), description=Description(value=description), extraField=extra-field)",
+                    "MySubModel(id=ModelId(value=111), name=my name is name, description=Description(value=description), extraField=extra-field)",
                     MySubModel(modelId, name, description, "extra-field").toString()
                 )
             }


### PR DESCRIPTION
Fixes #26

Depends on #27 #28 

I'm not sure what the problem was - but this seems to fix it when I test locally.

I wasn't able to re-create the issue so there's no test :(

If you want to preview this PR, then I've published it to the forked repo - just add a Maven repo to both the regular and plugin repositories

```kotlin
// settings.gradle.kts
fun RepositoryHandler.sekret() {
    // Access a PR version of Sekret while awaiting official fix: https://github.com/aafanasev/sekret/issues/26
    maven("https://raw.githubusercontent.com/aSemy/sekret/main/.m2") {
        content { includeGroup("net.afanasev") }
    }
}

@Suppress("UnstableApiUsage") // centralised repositories are incubating
dependencyResolutionManagement {

    repositories {
        mavenCentral()
        sekret()
    }

    pluginManagement {
        repositories {
            gradlePluginPortal()
            mavenCentral()
            sekret()
        }
    }
}
```
