### PR TITLE
Add Kotlin 2.4.0 support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "net.afanasev"
-version = "2.3.0"
+version = "2.4.0"
 
 tasks.wrapper {
     gradleVersion = "9.0.0"

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,10 +1,10 @@
 plugins {
     `kotlin-dsl`
-    kotlin("jvm") version "2.3.0"
+    kotlin("jvm") version "2.4.0"
 }
 
 // set the versions of Gradle plugins that the subprojects will use here
-val kotlinPluginVersion: String = "2.3.0"
+val kotlinPluginVersion: String = "2.4.0"
 
 dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom:$kotlinPluginVersion"))

--- a/kotlin-plugin/build.gradle.kts
+++ b/kotlin-plugin/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 
     testImplementation(kotlin("compiler-embeddable"))
     testImplementation("org.junit.jupiter:junit-jupiter:5.9.2")
-    testImplementation("dev.zacsweers.kctfork:core:0.12.0")
+    testImplementation("dev.zacsweers.kctfork:core:0.13.0")
     testImplementation(projects.annotation)
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }


### PR DESCRIPTION
## Summary

- Bumps Kotlin from `2.3.0` to `2.4.0` in `buildSrc/build.gradle.kts`, recompiling the plugin against the updated compiler API
- Bumps kctfork from `0.12.0` to `0.13.0` (the test runner's Kotlin 2.4.0 release)
- Bumps project version to `2.4.0`

## Root cause

In Kotlin 2.4.0, `IrGenerationExtension.Companion` changed its supertype from `ProjectExtensionDescriptor` to `ExtensionPointDescriptor`. The plugin binary compiled against 2.3.0 contained a `checkcast ProjectExtensionDescriptor` instruction that failed at runtime when loaded by the 2.4.0 compiler:

```
ClassCastException: IrGenerationExtension$Companion cannot be cast to ProjectExtensionDescriptor
    at SekretCompilerPluginRegistrar.registerExtensions(SekretCompilerPluginRegistrar.kt:29)
```

Recompiling against 2.4.0 makes the compiler pick the updated `ExtensionPointDescriptor<T>.registerExtension` member extension in `ExtensionStorage`, so no source changes to `SekretCompilerPluginRegistrar.kt` are needed.

The kctfork bump explains why "naively bumping only the Kotlin version compiles but tests fail" — the test runner itself needed updating to 2.4.0.

## Test plan

- [x] `./gradlew :kotlin-plugin:test` passes with Kotlin 2.4.0 and kctfork 0.13.0

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)